### PR TITLE
refactor: replace DELETE method with POST

### DIFF
--- a/src/api/events/index.ts
+++ b/src/api/events/index.ts
@@ -79,8 +79,8 @@ app.put(
 	}
 );
 
-app.delete(
-	'/:eventId',
+app.post(
+	'/:eventId/delete',
 	zValidator('query', DeleteEventQuerySchema),
 	async (c) => {
 		const accessToken = c.get('accessToken');


### PR DESCRIPTION
### Problem
- Tana does not support the DELETE HTTP method for `Make API request` command
- The DELETE `/events/:eventId` endpoint cannot be used

### Solution
- Replaced DELETE method with POST method to ensure Tana compatibility.
- Changed endpoint from DELETE /events/:eventId to POST /events/:eventId/delete

