### PR TITLE
feat: add GET endpoint for retrieving individual events

### DIFF
--- a/src/api/events/index.ts
+++ b/src/api/events/index.ts
@@ -12,6 +12,7 @@ import {
 	PutEventQuerySchema,
 	PutEventBodySchema,
 	DeleteEventQuerySchema,
+	GetEventQuerySchema,
 } from './schemas';
 import { DEFAULT_OPTIONS } from './constants';
 import * as eventService from './service';
@@ -56,6 +57,21 @@ app.post(
 		return c.text(ret);
 	}
 );
+
+app.get('/:eventId', zValidator('query', GetEventQuerySchema), async (c) => {
+	const accessToken = c.get('accessToken');
+	const { from: calendarId, fieldsToReturn } = c.req.valid('query');
+	const { eventId } = c.req.param();
+
+	const ret = await eventService.getEvent(
+		accessToken,
+		calendarId,
+		eventId,
+		fieldsToReturn
+	);
+
+	return c.text(ret);
+});
 
 app.put(
 	'/:eventId',

--- a/src/api/events/schemas.ts
+++ b/src/api/events/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { TanaDateInfoSchema } from '@/common/utils/handle-tana-date';
+import { DEFAULT_FIELDS_TO_RETURN } from './constants';
 
 export const EventDataSchema = z.object({
 	name: z.string().min(1, 'Event name is required').trim(),
@@ -59,6 +60,13 @@ export const PostEventQuerySchema = z.object({
 export const PostEventBodySchema = z.object({
 	data: EventDataSchema,
 	options: EventOptionsSchema.optional(),
+});
+
+export const GetEventQuerySchema = z.object({
+	from: z
+		.string({ required_error: 'from(Calendar ID) is required' })
+		.min(1, 'from(Calendar ID) cannot be empty'),
+	fieldsToReturn: EventFieldsToReturnSchema.default(DEFAULT_FIELDS_TO_RETURN),
 });
 
 export const PutEventQuerySchema = z.object({

--- a/src/api/events/service.ts
+++ b/src/api/events/service.ts
@@ -99,6 +99,34 @@ export async function createEvent(
 }
 
 /**
+ * Retrieves an existing event from the specified Google Calendar and returns event information
+ * formatted as Tana Paste content for seamless integration into Tana.
+ *
+ * @param accessToken - The Google Calendar client access token
+ * @param calendarId - The Google Calendar ID where the event is located
+ * @param eventId - The unique identifier of the event to be retrieved
+ * @param fieldsToReturn - Array of field configurations specifying which properties to include in the response:
+ *   - `field` (string): The display name for the field in Tana
+ *   - `property` (string): The corresponding property name from the event object (use "calendarId" for calendar ID)
+ *
+ * @returns Tana Paste formatted string containing the specified event fields
+ */
+export async function getEvent(
+	accessToken: string,
+	calendarId: string,
+	eventId: string,
+	fieldsToReturn: EventFieldsToReturn
+): Promise<string> {
+	const event = await gc.getEvent(accessToken, calendarId, eventId);
+
+	if (!event) {
+		throw new Error(`Event not found: ${eventId}`);
+	}
+
+	return buildTanaPaste(event, calendarId, fieldsToReturn);
+}
+
+/**
  * Updates an existing event in the specified Google Calendar with optional calendar migration.
  * Supports partial updates - only provided fields will be updated.
  *


### PR DESCRIPTION
### Problem
- API only supports bulk operations without granular event access

### Solution
- GET Endpoint: Added GET /events/:eventId endpoint to retrieve specific calendar events by ID
