### PR TITLE
fix: add missing buildSummary call for event name updates

### DIFF
--- a/src/api/events/service.ts
+++ b/src/api/events/service.ts
@@ -189,7 +189,7 @@ export async function updateEvent(
 		const updatedEventData = { ...event };
 
 		if (data.name !== undefined && data.name !== event.summary) {
-			updatedEventData.summary = data.name;
+			updatedEventData.summary = buildSummary(data.name, options);
 		}
 		if (
 			data.description !== undefined &&


### PR DESCRIPTION
### Problem
- Event name updates bypassed `buildSummary` function
- Missing application of formatting options during name updates

### Solution
- Add `buildSummary` function call when updating event summary from `data.name`
